### PR TITLE
Proof-read Spanish translation of es/outline/intro.md

### DIFF
--- a/es/outline/intro.md
+++ b/es/outline/intro.md
@@ -155,8 +155,8 @@ Introducción a la Programación en Clojure
 
 #### Argumentos <button class="link" ng-bind-html="details" ng-model="block33" ng-click="block33=!block33"></button>
 
-> La mayoria de las funciones usan _argumentos_. En Clojure, se consideran
-> argumentos todo lo que esté dentro de los parentesis después de la función.
+> La mayoría de las funciones usan _argumentos_. En Clojure, se consideran
+> argumentos todo lo que esté dentro de los paréntesis después de la función.
 > En nuestro ejemplo, la función `print-str` utiliza la cadena de texto
 > `"¡Hola, mundo!"` como argumento; y, como retorno, muestra esa misma cadena por
 > pantalla. Luego, la función `+` utiliza los números `3` y `4` como argumentos,
@@ -174,7 +174,7 @@ Introducción a la Programación en Clojure
 
 > Al escribir código, la idea es hacerlo de la forma más clara y legible
 > posible. Esto es crítico, puesto que nuestro código seguramente va a ser
-> releido en un futuro (poco o muy distante). Y, dado el suficiente tiempo,
+> releído en un futuro (poco o muy distante). Y, dado el suficiente tiempo,
 > poco va a importar si fuimos nosotras/os mismas/os quienes escribimos el
 > código en un principio: seguramente nos habremos olvidado no sólo de por qué
 > lo escribimos de una manera determinada, sino de hasta qué hace. _(Y, creeme

--- a/es/outline/intro.md
+++ b/es/outline/intro.md
@@ -43,6 +43,7 @@ Introducción a la Programación en Clojure
 > aprender a programar --o simplemente, un lenguaje buenísimo para agregar a tu
 > lista de lenguajes conocidos:
 {: ng-show="block11" .description}
+
 #### Clojure es _simple_ <button class="link" ng-bind-html="details" ng-model="block12" ng-click="block12=!block12"></button>
 
 > Clojure es _simple_. Esto no quiere decir que no sea poderoso; lo es. El

--- a/es/outline/intro.md
+++ b/es/outline/intro.md
@@ -31,42 +31,44 @@ Introducción a la Programación en Clojure
 
 #### <button class="link" ng-model="block11" ng-click="block11=!block11">Intro</button>
 
-> Si nunca programaste antes, puede que no sepas que hay muchos lenguages
-> de dónde elegir. Puede que hayas escuchado de otros lenguajes
-> (o escucharás de ellos!) como C, JavaScript, Python y
+> Si nunca programaste antes, puede que no sepas que hay muchos lenguajes
+> para elegir. Algunos de los lenguajes de los que tengas conocimiento (¡o
+> vayas a tener conocimiento!) son: C, JavaScript, Python y
 > Java.
 {: ng-show="block11" .description}
 
-> Entonces ¿por qué estamos enseñanado Clojure? Aunque no es tan popular
-> como algunos de esos lenguajes, estamos usando Clojure por tres cualidades
-> que tiene que lo hacen ideal como primer lenguaje para aprender
-> (o un gran lenguaje para aprender) además de otros que tal vez ya conozcas:
+> Entonces ¿por qué estamos enseñanado Clojure? Si bien Clojure no es tan popular
+> como algunos de esos otros lenguajes que nombramos arriba, lo estamos usando
+> por tres cualidades que lo hacen ideal como primer lenguaje para
+> aprender a programar --o simplemente, un lenguaje buenísimo para agregar a tu
+> lista de lenguajes conocidos:
 {: ng-show="block11" .description}
-
 #### Clojure es _simple_ <button class="link" ng-bind-html="details" ng-model="block12" ng-click="block12=!block12"></button>
 
 > Clojure es _simple_. Esto no quiere decir que no sea poderoso; lo es. El
-> número de conceptos que tienes que saber para programar en Clojure es muy
-> pequeño y fácil de entender. Clojure crece con vos mientras lo
-> estas aprendiendo, y puedes ser muy productivo con un pequeño subconjunto
+> número de conceptos que tenés que saber para programar en Clojure es muy
+> pequeño y fácil de entender. Clojure crece con vos a medida que lo
+> aprendés, y podés ser muy productiva/o con un pequeño subconjunto
 > del lenguaje.
 {: ng-show="block12" .description}
 
-#### Clojure es de _proposito general_ <button class="link" ng-bind-html="details" ng-model="block13" ng-click="block13=!block13"></button>
+#### Clojure es _de proposito general_ <button class="link" ng-bind-html="details" ng-model="block13" ng-click="block13=!block13"></button>
 
-> Clojure es de _proposito general_. Algunos lenguajes tienen un foco específico.
-> JavaScript, por ejemplo, fue tradicionalmente usado solo en páginas web
-> (aunque eso ha cambiado de alguna manera). Objective-C es usado principalmente
-> para aplicaciones iPhone. Hoy vamos a hacer una aplicación para dibujar,
-> pero puedes usar Clojure para cualquier tipo de aplicación facilmente.
+> Clojure es _de propósito general_. Algunos lenguajes están focalizados
+> en algo específico.
+> JavaScript, por ejemplo, en un principio fue usado sólo en páginas web
+> (aunque eso ha cambiado de alguna manera). Objective-C se usa principalmente
+> para aplicaciones iPhone.
+> Si bien hoy vamos a hacer una aplicación para dibujar,
+> fácilmente podés usar Clojure para cualquier tipo de aplicación.
 {: ng-show="block13" .description}
 
-#### Clojure es _diversión_ <button class="link" ng-bind-html="details" ng-model="block14" ng-click="block14=!block14"></button>
+#### Clojure es _divertido_ <button class="link" ng-bind-html="details" ng-model="block14" ng-click="block14=!block14"></button>
 
-> Clojure es _diversión_. Eso es una cuestión de opinión, por supuesto, pero
-> pensamos que es verdad. Esperamos que durante este curso experimenten
-> la alegría de construir un programa hecho en Clojure y hacer algo
-> poderoso y sorprendente.
+> Clojure es _divertido_. Si bien eso es una cuestión de opinión, nosotros
+> pensamos que es así. En este curso, esperamos que, mientras construís un
+> programa en Clojure, experimentés la alegría de crear algo poderoso y
+> sorprendente.
 {: ng-show="block14" .description}
 </section>
 

--- a/es/outline/intro.md
+++ b/es/outline/intro.md
@@ -22,7 +22,7 @@ Introducción a la Programación en Clojure
 * ¿Cómo se ve Clojure?
     - Comentarios
 * ¿Qué es un REPL?
-* El REPL en acción
+* Un REPL en acción
 </section>
 
 <section ng-controller="NarrativeController">
@@ -224,26 +224,29 @@ Introducción a la Programación en Clojure
 </section>
 
 <section ng-controller="NarrativeController">
-## El REPL en acción
+## Un REPL en acción
 {: .slide_title .slide}
 
 
-#### Nightcode InstaREPL <button class="link" ng-bind-html="details" ng-model="block61" ng-click="block61=!block61"></button>
+#### El InstaREPL de Nightcode <button class="link" ng-bind-html="details" ng-model="block61" ng-click="block61=!block61"></button>
 
 > Para interactuar con Clojure, podemos usar el InstaREPL de Nightcode.
-> esta es una buena manera de jugar con Clojure interactivamente.
+> Ésta es una buena manera de jugar con Clojure de forma interactiva.
 {: ng-show="block61" .description}
 
 
-#### Usando el REPL <button class="link" ng-bind-html="details" ng-model="block62" ng-click="block62=!block62"></button>
+#### Cómo usar el REPL de Nightcode <button class="link" ng-bind-html="details" ng-model="block62" ng-click="block62=!block62"></button>
 
 > Nightcode tiene un seteo de proyecto conectado con el REPL en el panel de abajo.
-> Cuando el botón "Run with REPL" es clickeado, el REPL empieza.
+> Para usar su REPL incorporado, hay que hacer click ("pinchar") en el botón
+> "Run with REPL".
 {: ng-show="block62" .description}
 
-> Alternativamente, podemos iniciar un  REPL usando leiningen en una terminal (sin
-> Nightcode).
-> En una terminal, escribe `lein repl`, entonces el REPL iniciará.
+> Otra opción para iniciar un REPL sin utilizar Nightcode en una terminal es
+> usar Leiningen (una herramienta para facilitar el manejo de todo lo necesario
+> para que tu programa pueda ser ejecutado con la máquina; en la jerga de
+> programación, un _administrador de dependencias_).
+> Para iniciar el REPL de Leiningen, en una terminal, escribí `lein repl`.
 > Si ejecutamos `lein repl`  en el directorio del proyecto (carpeta), verás
 > la configuración.
 {: ng-show="block62" .description}
@@ -259,32 +262,32 @@ Introducción a la Programación en Clojure
 </section>
 
 <section>
-#### EJERCICIO 1: Prueba el InstaREPL de Nightcode
+#### EJERCICIO 1: Probá el InstaREPL de Nightcode
 
-1. Inicia Nightcode
-2. Importa `myproject` <br/> (el cual creaste mientras testeabas el setup de leiningen)
+1. Iniciá Nightcode
+2. Importá `myproject` <br/> (el que creaste mientras probabas la configuración de Leiningen)
 3. Abrí `core.clj` <br/>(`myproject` -> `src` -> `myproject` -> `core.clj`
-4. Hacé click en el  __InstREPL__ botón
-5. Escribí las funciones Clojure escritas abajo y observa qué pasa
+4. Hacé click ("pinchá") en el botón __InstaREPL__
+5. Escribí las funciones en Clojure que aparecen abajo; observá qué pasa
 
 ```clojure
-(print-str "Hola, Mundo!")
-(print-str "Hola, Mundo!" " " "desde Clojure")
+(print-str "Hola, mundo!")
+(print-str "Hola, mundo!" " " "desde Clojure")
 (+ 3 4)
 (- 3 4)
 (* 3 4)
 ```
-> Asegurate de tipear las líneas  <em>exactamente</em> como las ves,
-> teniendo cuidado de poner los paréntesis en el lugar correcto.
+> Asegurate de tipear las líneas <em>tal cual</em> se ven.
+> En particular, asegurate de que los paréntesis vayan en el lugar correcto.
 </section>
 
 <section>
 #### EJERCICIO 2: Evaluar un archivo y una línea - Parte 1
 
 * Abrí el archivo `welcometoclojurebridge/src/clojurebridge_turtle/walk.clj`
-* Evaluá todo el archivo presionando "Run with REPL" seguido de "Reload File"
+* Para evaluar todo el archivo, hacé click en "Run with REPL", y luego en "Reload File"
 * Mirá qué pasa después
-* Tipeá `(forward 40)` al fondo del archivo `walk.clj` en el editor. Evaluá esta línea eligiendo la línea y presionando "Reload Selection"
+* Al final del archivo `walk.clj`, tipeá `(forward 40)`. Para evaluar esta línea, seleccionala y hacé click en "Reload Selection"
 * Mirá qué pasa después
 
 (Continúa en el EJERCICIO 3)
@@ -295,29 +298,29 @@ Introducción a la Programación en Clojure
 
 (Suponiendo que el EJECICIO 2 está terminado)
 
-* Tipeá `(right 90)` y "enter" en el REPL (al fondo) ![Run with REPL pane](img/run-with-repl.png)
+* En la parte inferior del REPL, tipeá `(right 90)` y "enter" ![Panel "Run with REPL"](img/run-with-repl.png)
 * Mirá qué pasa con la tortuga
-* Pegale una mirada a [Tortugas App API](https://github.com/ClojureBridge/welcometoclojurebridge/blob/master/outline/TURTLE.md) y
-[Cómo pasear Tortugas](https://github.com/ClojureBridge/welcometoclojurebridge/blob/master/outline/TURTLE-SAMPLES.md)
-[sección 1 y 2], y prueba más comandos para pasear tu tortuga
+* Pegale una mirada a [API de la App Tortugas](https://github.com/ClojureBridge/welcometoclojurebridge/blob/master/outline/TURTLE.md) y
+[Cómo pasear tortugas](https://github.com/ClojureBridge/welcometoclojurebridge/blob/master/outline/TURTLE-SAMPLES.md)
+[sección 1 y 2], y probá más comandos para pasearle a tu tortuga
 </section>
 
 <section>
 #### EJERCICIO 4: Mirar los docs de Clojure
 
-* En el fondo del REPL, intentá mirar la  documentación para las funciones usadas
-* Podés usar el comando `(doc function-name)` para esto
-* Probá `(doc +)` y `(doc forward)` en el REPL
-* Probá algun otra función que hayamos usado, por ejemplo, `-`, `*`, o `doc`
+* En la parte inferior del REPL, probá ver la  documentación para las funciones usadas
+* Para ver la documentación, podés usar el comando `(doc <nombre-de-la-función>)`
+* En el REPL, probá `(doc +)` y `(doc forward)`
+* Probá alguna otra función que hayas usado, por ejemplo, `-`, `*`, o `doc`
 </section>
 
 {% comment %}
 
-:star2: El link siguiente es para un slide solo. Andá al[README.md](../README.md). :star2:
+:star2: El enlace siguiente es para un slide solo. Ir al[README.md](../README.md). :star2:
 
 {% endcomment %}
 
 <section>
-Volvé al <a href="javascript:;" onClick="Reveal.slide(1);">primer slide</a>,
-o andá al [outline del curriculum](/curriculum/es/#/1).
+Volver al <a href="javascript:;" onClick="Reveal.slide(1);">primer slide</a>,
+o ir al [outline del curriculum](/curriculum/es/#/1).
 </section>

--- a/es/outline/intro.md
+++ b/es/outline/intro.md
@@ -18,7 +18,7 @@ Introducción a la Programación en Clojure
 {: .slide-title .chapter}
 
 * ¿Por qué Clojure?
-* ¿En qué es bueno Clojure?
+* ¿Para qué es bueno Clojure?
 * ¿Qué tal se ve Clojure?
     - Comentarios
 * Qué es el REPL?
@@ -73,37 +73,48 @@ Introducción a la Programación en Clojure
 </section>
 
 <section ng-controller="NarrativeController">
-## ¿En qué es bueno Clojure?
+## ¿Para qué es bueno Clojure?
 {: .slide_title .slide}
 
 #### <button class="link" ng-model="block21" ng-click="block21=!block21">Intro</button>
 
-> Entonces, dijimos que Clojure es de propósito general, y lo es. Eso no significa
-> que no tenga puntos fuertes.
+> Ya dijimos que Clojure es de propósito general, por lo que sirve para hacer de
+> todo. Claro que tiene sus puntos fuertes...
 {: ng-show="block21" .description}
 
 #### Procesamiento de datos <button class="link" ng-bind-html="details" ng-model="block22" ng-click="block22=!block22"></button>
 
-> Clojure es reconocido por hacer un buen procesamiento de datos. Esto es
-> porque tiene un buen set de estructuras de datos. Es decir, que tiene muchas
-> maneras incorporadas de representar datos que lo hacen fácil y poderoso.
+> Clojure es reconocido por ser bueno para procesar datos. Esto es
+> porque tiene un buen conjunto de estructuras de datos. Es decir, que ya tiene
+> incorporadas muchas maneras de representar datos útiles y poderosas.
 {: ng-show="block22" .description}
 
 #### Concurrencia <button class="link" ng-bind-html="details" ng-model="block23" ng-click="block23=!block23"></button>
 
-> Clojure es reconocido por su concurrencia. Pensá acerca de escribir
-> instrucciones para cuatro de tus amigos sobre cómo construir una casa del
-> árbol, pero en vez de escribirlas de manera que un sólo paso es realizado
-> a la vez, cada uno de tus amigos hace parte del trabajo. Entonces, ellos
-> coordinan el momento exacto para ensamblar esas partes en partes más
-> grandes, y hacen esto una y otra vez hasta el final, cuando todas
-> las partes se juntan. Estas instrucciones pueden ser realmente complicadas
-> y difíciles de escribir (y probablemente difíciles de leer también).
-> Clojure nos da algunas maneras fáciles de escribir este tipo de
-> instrucciones para computadoras.
+> Clojure es reconocido por su concurrencia. Concurrencia es una manera de
+> hacer las cosas que, en ciertos casos, puede llegar a ser más eficiente
+> que hacerlo en forma secuencial.
+> _(Trabajar en forma secuencial quiere
+> decir: primero, definimos un orden para construir los componentes que
+> necesitamos; luego, comenzamos por el primer componente de la lista,
+> haciendo de a uno a la vez (aunque en eso trabajemos varias/os); y sólo
+> podemos avanzar al siguiente elemento de la lista cuando todos sus
+> predecesores hayan sido terminados.)_
+> Supongamos que querés escribir las instrucciones apropiadas para construir
+> una casa de árbol de a cuatro amigas/os de forma tal que permitan que cada
+> una/o trabaje en el o los componentes que desee y que coordinen en el
+> momento justo para para ir ensamblando las partes ya construidas hasta
+> ese momento, generando partes más complejas, hasta que al final, estén
+> combinadas todas las piezas.
+> Escribir (y eventualmente leer) tales instrucciones podría llegar a ser bastante difícil de
+> escribir... a menos que contaras con herramientas lingüísticas que te ayuden
+> a hacerlo.
+> Volviendo de nuestro ejemplo al ámbito de la programación, Clojure viene con
+> herramientas incorporadas que nos facilita el escribir "instrucciones para
+> computadoras" que resuelven problemas de esta manera.
 {: ng-show="block23" .description}
 
-#### Todo! <button class="link" ng-bind-html="details" ng-model="block24" ng-click="block24=!block24"></button>
+#### ¡Todo! <button class="link" ng-bind-html="details" ng-model="block24" ng-click="block24=!block24"></button>
 
 > Clojure también sirve para construir aplicaciones de dibujo con
 > [Quil](https://github.com/quil/quil), con el cual vamos a hacer algo

--- a/es/outline/intro.md
+++ b/es/outline/intro.md
@@ -21,7 +21,7 @@ Introducción a la Programación en Clojure
 * ¿Para qué es bueno Clojure?
 * ¿Cómo se ve Clojure?
     - Comentarios
-* Qué es el REPL?
+* ¿Qué es un REPL?
 * El REPL en acción
 </section>
 
@@ -202,23 +202,24 @@ Introducción a la Programación en Clojure
 </section>
 
 <section>
-## ¿Qué es el REPL?
+## ¿Qué es un REPL?
 {: .slide_title .slide}
 
 #### <button class="link" ng-model="block51" ng-click="block51=!block51">Intro</button>
 
-> "REPL" significa "Leer-Evaluar-Imprimir-Loop" (del inglés "Read-Eval-Print-Loop")
-> lo cual no tieme mucho sentido sin el contexto.
-> Muchos lenguajes de programación, incluyendo Clojure,
-> tienen una manera de escribir código interactivamente, con el cual puedes
-> tener una respuesta instantanea. En otras palabras, el código es leído,
-> luego es evaluado,
-> el resultado es impreso en pantalla, y comienza nuevamente: un loop.
+> "REPL" es la sigla en inglés para "Ciclo de Lectura, Evaluación e Impresión"
+> ("Read-Eval-Print-Loop"). Pero... ¿qué quiere decir esto?
+> Muchos lenguajes de programación (y entre ellos, Clojure) tienen una manera de
+> escribir código en forma interactiva. De este modo, podés obtener respuestas
+> instantáneas a tus instrucciones. En otras palabras, el REPL se encarga de
+> (sucesivamente) leer el código que se le ingresa, evaluarlo e imprimir el
+> resultado correspondiente. Luego, es posible comenzar de nuevo (hacer un
+> ciclo).
 {: ng-show="block51" .description}
 
 **R**ead, **E**val, **P**rint, **L**oop
 
-![El repl de Nightcode](img/repl.png)
+![El REPL de Nightcode](img/repl.png)
 
 </section>
 

--- a/es/outline/intro.md
+++ b/es/outline/intro.md
@@ -19,7 +19,7 @@ Introducción a la Programación en Clojure
 
 * ¿Por qué Clojure?
 * ¿Para qué es bueno Clojure?
-* ¿Qué tal se ve Clojure?
+* ¿Cómo se ve Clojure?
     - Comentarios
 * Qué es el REPL?
 * El REPL en acción
@@ -123,43 +123,45 @@ Introducción a la Programación en Clojure
 </section>
 
 <section ng-controller="NarrativeController">
-## ¿Qué tal se ve Clojure?
+## ¿Cómo se ve Clojure?
 {: .slide_title .slide}
 
 ```clojure
-(print-str "Hello, World!")
+(print-str "¡Hola, mundo!")
 (+ 3 4)
 (forward :trinity 40)
 ```
 
 #### Paréntesis <button class="link" ng-bind-html="details" ng-model="block31" ng-click="block31=!block31"></button>
 
-> Viste los paréntesis?. Los paréntesis encierran instrucciones para la
-> computadora en Clojure. Un paréntesis izquierdo
-> es el comienzo de una instrucción, y su respectivo paréntesis derecho es
-> el final de una instrucción. Normalmente, el código Clojure tiene un montón
-> de paréntesis anidados, en otras palabras, los paréntesis anidados encierran
-> instrucciones.
+> ¿Viste los paréntesis?. En Clojure, cada par de paréntesis encierra una
+> instrucción para la computadora. Normalmente, el código Clojure tiene un montón de paréntesis anidados. O sea,
+> los paréntesis anidados encierran instrucciones.
 {: ng-show="block31" .description}
 
 #### Funciones <button class="link" ng-bind-html="details" ng-model="block32" ng-click="block32=!block32"></button>
 
-> Después de los paréntesis, veremos las instrucciones para la computadora.
-> Esa instrucción es lo que normalmente llamamos una _función_.
-> Las funciones hacen todo el trabajo duro en Clojure.
-> `print-str`, `+` y `forward` son funciones.
-> Cuando estas funciones se ejecutan, ellas retornan algún tipo de valor.
-> En Clojure las funciones siempre retornan un valor.
+> Como dijimos arriba, dentro de los paréntesis están las instrucciones para la
+> computadora. En Clojure, cada instrucción es una _función_, y hacen la parte
+> más dura del trabajo. En nuestro ejemplo de arriba, tanto `print-str`, `+`
+> como `forward` son funciones.
+> Una de las características de las funciones es que siempre que se ejecutan
+> sobre uno o más valores para el o los cuales están definidas devuelven una
+> respuesta. La respuesta puede ser ya sea un valor de un tipo determinado (un
+> número, uno o más caracteres, etc.) o "nada". En Clojure, el equivalente de
+> "nada" es `nil`.
 {: ng-show="block32" .description}
 
 #### Argumentos <button class="link" ng-bind-html="details" ng-model="block33" ng-click="block33=!block33"></button>
 
-> La mayoria de las funciones usan _argumentos_ (es todo aquello dentro de los
-> parentesis después de la función).
-> `print-str` utiliza "Hello, World!" y retorna una cadena de caracteres.
-> `+` utiliza 3 y 4, los suma, y devuelve 7.
-> `forward` utiliza :trinity y 40, mueve la tortuga en 40 y retorna
-> el resultado.
+> La mayoria de las funciones usan _argumentos_. En Clojure, se consideran
+> argumentos todo lo que esté dentro de los parentesis después de la función.
+> En nuestro ejemplo, la función `print-str` utiliza la cadena de texto
+> `"¡Hola, mundo!"` como argumento; y, como retorno, muestra esa misma cadena por
+> pantalla. Luego, la función `+` utiliza los números `3` y `4` como argumentos,
+> los suma, y devuelve el número `7`.
+> Finalmente, la función `forward` utiliza la clave `:trinity` y el número `40`,
+> mueve la tortuga 40 unidades y retorna el resultado.
 {: ng-show="block33" .description}
 </section>
 
@@ -169,28 +171,32 @@ Introducción a la Programación en Clojure
 <button class="link" ng-bind-html="details1" ng-model="block41" ng-click="block41=!block41"></button>
 <button class="link" ng-bind-html="details2" ng-model="block42" ng-click="block42=!block42"></button>
 
-> Cuando escribimos código, trataremos de que sea lo más claro posible. Esto es
-> un gran avance porque nuestro código puede ser leido por otros (a veces
-> más que por nosotros mismos!), o podemos volver a leer nuestro propio código
-> más tarde, y puede ser que hayamos olvidado cada detalle
-> del código. Una manera de clarificar nuestro código es haciendo
-> anotaciones con comentarios. Los comentarios son notas que agregamos al código,
-> para nuestro propio bien, y que la computadora ignora.
+> Al escribir código, la idea es hacerlo de la forma más clara y legible
+> posible. Esto es crítico, puesto que nuestro código seguramente va a ser
+> releido en un futuro (poco o muy distante). Y, dado el suficiente tiempo,
+> poco va a importar si fuimos nosotras/os mismas/os quienes escribimos el
+> código en un principio: seguramente nos habremos olvidado no sólo de por qué
+> lo escribimos de una manera determinada, sino de hasta qué hace. _(Y, creeme
+> hay muuuchos ejemplos en Internet de esto último.)_
+> Una manera de hacer nuestro código más claro y legible es agregandole notas
+> explicativas. En programación, a estas notas explicativas agregadas al código
+> (a ser ignoradas por la computadora) se las llama _comentarios_.
 {: ng-show="block41" .description}
 
-> En Clojure, los comentarios pueden ser comenzados con un punto y coma. Todo lo
-> que va después de un punto y coma hasta el final de la línea es un comentario que
-> es ignorado por la computadora. Solo un punto y coma es necesario, pero
-> a veces puedes ver dos punto y coma en una fila, dependiendo del estilo
-> usado.
+> En Clojure, los comentarios comienzan con un punto y coma (`;`). Todo lo
+> que escribamos a continuación de un punto y coma (hasta el final de la línea)
+> va a ser ignorado por la computadora. _(Si bien en Clojure sólo hace falta un
+> sólo punto y coma para iniciar un comentario, dependiendo de las preferencias
+> de la desarrolladora (o desarrollador), a veces pueden verse dos (`;;`).
+> En ambos casos, se suele dejar un espacio antes de escribir el texto del comentario.)_
 {: ng-show="block42" .description}
 
 > Referencia: [Comment](http://clojurebridge.github.io/community-docs/docs/clojure/comment/)
 {: ng-show="block42" .description}
 
 ```clojure
-;; ejemplo de funciones de un slide anterior
-(print-str "Hola, Mundo!")   ; el bien-conocido "hola mundo"
+;; funciones del ejemplo anterior, con comentarios
+(print-str "¡Hola, Mundo!")   ; el bien-conocido "hola mundo"
 (+ 3 4)                      ; ¿por qué no 3 + 4? lo veremos después
 ```
 </section>


### PR DESCRIPTION
This is the criteria I used (which I propose to the rest of the team as a basis on which to agree for consistent use across the whole translation effort):

1) consistently use "voseo"
(it was mixed up with "tuteo" --plus, it is what we will use for this ClojureBridge edition anyways; personally, I find "neutral" Spanish quite boring, and I cannot find a compelling reason to consider it unavoidable for this particular case  :-)

2) privilege a feminine writing gender
(after all, we are targeting women, right?)